### PR TITLE
fixes mozilla/discourse#212

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -79,7 +79,7 @@ tr[data-category-id="275"] {
 /* Hide Common Voice subcategory topics */
 
 .category-voice .topic-list .topic-list-item:not(.category-voice) {
-  display: none;
+  visibility: collapse;
 }
 
 /* Dinopark-style buttons */


### PR DESCRIPTION
Replacing `display: none;` with `visibility: collapse;` resolves the issue in mozilla/discourse#212. Works in Chrome and Firefox on desktop. 